### PR TITLE
Fixed crash whenever viewing stats

### DIFF
--- a/scripts/Initalization/Initalization.gml
+++ b/scripts/Initalization/Initalization.gml
@@ -51,6 +51,7 @@ function Initialize()
 	InitalizeItem();
 	InitalizeCell();
 	COALITION_DATA.AttackItem = global.__Coalition_Equipments.__equipment_list[$ "Burnt Pan"];
+	COALITION_DATA.DefenseItem = global.__Coalition_Equipments.__equipment_list[$ "Stained Apron"];
 	ConvertItemNameToStat();
 }
 


### PR DESCRIPTION
<img width="697" height="657" alt="Captura de pantalla 2025-10-06 031345" src="https://github.com/user-attachments/assets/ae2cf723-8f08-4668-b2f5-29dbac3c1004" />

A fix for a bug I found out just recently while using the new patch (yet, from what I have tested, it also happens on earlier builds):
Whenever the STATS menu is viewed in any overworld room, the game inmeteadly crashes. due to the player's equipped armor, and thus, armor DEF not being set. being unable to draw it. 

This can be simply be fixed by setting any armor as equipped by default on the Initalization script (In this case, I have set it as the stained apron. Also, quite strange how the default weapon was already set, but the default armor not, thus causing the crash,)
